### PR TITLE
faet: add link to PolkadotJS Apps directly

### DIFF
--- a/src/att-key-set.ts
+++ b/src/att-key-set.ts
@@ -5,7 +5,8 @@ import * as Kilt from '@kiltprotocol/sdk-js'
 import * as utils from './utils'
 
 async function main() {
-  const api = await Kilt.connect(utils.readWsAddress())
+  const apiAddress = utils.readWsAddress()
+  const api = await Kilt.connect(apiAddress)
 
   const submitterAddress = process.env[
     utils.envNames.submitterAddress
@@ -63,6 +64,9 @@ async function main() {
   console.log(
     // eslint-disable-next-line max-len
     `New assertion method key operation: ${encodedOperation}. Please submit this via PolkadotJS with the account that was provided: ${submitterAddress}.`
+  )
+  console.log(
+    `Direct link: ${utils.generatePolkadotJSLink(apiAddress, encodedOperation)}`
   )
 }
 

--- a/src/auth-key-set.ts
+++ b/src/auth-key-set.ts
@@ -5,7 +5,8 @@ import * as Kilt from '@kiltprotocol/sdk-js'
 import * as utils from './utils'
 
 async function main() {
-  const api = await Kilt.connect(utils.readWsAddress())
+  const apiAddress = utils.readWsAddress()
+  const api = await Kilt.connect(apiAddress)
 
   const submitterAddress = process.env[
     utils.envNames.submitterAddress
@@ -63,6 +64,9 @@ async function main() {
   console.log(
     // eslint-disable-next-line max-len
     `New authentication key operation: ${encodedOperation}. Please submit this via PolkadotJS with the account that was provided: ${submitterAddress}.`
+  )
+  console.log(
+    `Direct link: ${utils.generatePolkadotJSLink(apiAddress, encodedOperation)}`
   )
 }
 

--- a/src/call-sign.ts
+++ b/src/call-sign.ts
@@ -5,7 +5,8 @@ import * as Kilt from '@kiltprotocol/sdk-js'
 import * as utils from './utils'
 
 async function main() {
-  const api = await Kilt.connect(utils.readWsAddress())
+  const apiAddress = utils.readWsAddress()
+  const api = await Kilt.connect(apiAddress)
 
   const submitterAddress = process.env[
     utils.envNames.submitterAddress
@@ -89,6 +90,9 @@ async function main() {
   console.log(
     // eslint-disable-next-line max-len
     `Encoded DID-authorized operation: ${encodedOperation}. Please submit this via PolkadotJS with the account that was provided: ${submitterAddress}.`
+  )
+  console.log(
+    `Direct link: ${utils.generatePolkadotJSLink(apiAddress, encodedOperation)}`
   )
 }
 

--- a/src/del-key-set.ts
+++ b/src/del-key-set.ts
@@ -5,7 +5,8 @@ import * as Kilt from '@kiltprotocol/sdk-js'
 import * as utils from './utils'
 
 async function main() {
-  const api = await Kilt.connect(utils.readWsAddress())
+  const apiAddress = utils.readWsAddress()
+  const api = await Kilt.connect(apiAddress)
 
   const submitterAddress = process.env[
     utils.envNames.submitterAddress
@@ -63,6 +64,9 @@ async function main() {
   console.log(
     // eslint-disable-next-line max-len
     `New capability delegation key operation: ${encodedOperation}. Please submit this via PolkadotJS with the account that was provided: ${submitterAddress}.`
+  )
+  console.log(
+    `Direct link: ${utils.generatePolkadotJSLink(apiAddress, encodedOperation)}`
   )
 }
 

--- a/src/did-create.ts
+++ b/src/did-create.ts
@@ -7,7 +7,8 @@ import * as Kilt from '@kiltprotocol/sdk-js'
 import * as utils from './utils'
 
 async function main() {
-  await Kilt.connect(utils.readWsAddress())
+  const apiAddress = utils.readWsAddress()
+  await Kilt.connect(apiAddress)
 
   const submitterAddress = process.env[
     utils.envNames.submitterAddress
@@ -59,6 +60,9 @@ async function main() {
   console.log(
     // eslint-disable-next-line max-len
     `Encoded DID creation operation: ${encodedOperation}. Please submit this via PolkadotJS with the account that was provided: ${submitterAddress}.`
+  )
+  console.log(
+    `Direct link: ${utils.generatePolkadotJSLink(apiAddress, encodedOperation)}`
   )
 }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -208,3 +208,10 @@ export function generateNewAuthenticationKey():
     return undefined
   }
 }
+
+export function generatePolkadotJSLink(
+  wsAddress: string,
+  encodedExtrinsic: `0x${string}`
+): string {
+  return `https://polkadot.js.org/apps/?rpc=${wsAddress}#/extrinsics/decode/${encodedExtrinsic}`
+}


### PR DESCRIPTION
The output of each script now contains a direct link to the Extrinsic tab of the PolkadotJS Apps website.